### PR TITLE
Bump go version from 1.8 to 1.10.8

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/cloudfoundry-community/worlds-simplest-service-broker",
-	"GoVersion": "go1.8",
+	"GoVersion": "go1.10.8",
 	"GodepVersion": "v74",
 	"Deps": [
 		{


### PR DESCRIPTION
- this is the latest version supported by both e2e cf and cfdev